### PR TITLE
pass correct parameter to Invoke-DQVTesting in CICD pipeline

### DIFF
--- a/DAX Query View Testing Pattern/scripts/Run-CICD.yml
+++ b/DAX Query View Testing Pattern/scripts/Run-CICD.yml
@@ -221,7 +221,7 @@ jobs:
             Invoke-DQVTesting -WorkspaceName "${env:WORKSPACE_NAME}" `
                               -Credential $credential `
                               -TenantId "${env:TENANT_ID}" `
-                              -DatasetId $datasetsToTest `
+                              -DatasetId $promotedItem.Id `
                               -LogOutput "ADO"
             
         }# end foreach

--- a/DAX Query View Testing Pattern/scripts/Run-CICD.yml
+++ b/DAX Query View Testing Pattern/scripts/Run-CICD.yml
@@ -207,7 +207,6 @@ jobs:
 
         # Run synchronous refresh for each semantic model
         foreach($promotedItem in $sMPromotedItems){
-            $refreshResult = $null
 
             # Test refresh which validates functionality
             Invoke-SemanticModelRefresh -WorkspaceId $workspaceID `


### PR DESCRIPTION
Pass correct parameter to Invoke-DQVTesting so only the changed and refreshed semantic models are tested.