### PR TITLE
bump Microsoft.AnalysisServices version to 19.84.1

### DIFF
--- a/DAX Query View Testing Pattern/modules/Invoke-DQVTesting/Invoke-DQVTesting.psm1
+++ b/DAX Query View Testing Pattern/modules/Invoke-DQVTesting/Invoke-DQVTesting.psm1
@@ -43,18 +43,18 @@ foreach ($nuget in $nugets)
 }
 
 # Create a new directory in the current location
-if((Test-Path -path ".\.nuget\custom_modules") -eq $false){
-    New-Item -Name ".nuget\custom_modules" -Type Directory
+if((Test-Path -path "$currentPath\.nuget\custom_modules") -eq $false){
+    New-Item -Path "$currentPath\.nuget\custom_modules" -Type Directory 
 }
 
 # For each url download and install in module folder
 @("https://raw.githubusercontent.com/microsoft/Analysis-Services/master/pbidevmode/fabricps-pbip/FabricPS-PBIP.psm1",
     "https://raw.githubusercontent.com/microsoft/Analysis-Services/master/pbidevmode/fabricps-pbip/FabricPS-PBIP.psd1") | ForEach-Object {
-    Invoke-WebRequest -Uri $_ -OutFile ".\.nuget\custom_modules\$(Split-Path $_ -Leaf)"
+    Invoke-WebRequest -Uri $_ -OutFile "$currentPath\.nuget\custom_modules\$(Split-Path $_ -Leaf)"
 }
 
 # Import FabricPS-PBIP
-Import-Module ".\.nuget\custom_modules\FabricPS-PBIP" -Force
+Import-Module "$currentPath\.nuget\custom_modules\FabricPS-PBIP" -Force
 
 # Check to see if the type already exists
 # This is used identify which Power BI Reports are opened locally

--- a/DAX Query View Testing Pattern/modules/Invoke-DQVTesting/Invoke-DQVTesting.psm1
+++ b/DAX Query View Testing Pattern/modules/Invoke-DQVTesting/Invoke-DQVTesting.psm1
@@ -16,7 +16,7 @@ $nugets = @(
     @{
         name = "Microsoft.AnalysisServices.AdomdClient.NetCore.retail.amd64"
         ;
-        version = "19.77.0"
+        version = "19.84.1"
         ;
         path = @("lib\netcoreapp3.0\Microsoft.AnalysisServices.AdomdClient.dll",
                  "lib\netcoreapp3.0\Microsoft.AnalysisServices.Runtime.Core.dll",

--- a/DAX Query View Testing Pattern/modules/Invoke-DQVTesting/Invoke-DQVTesting.psm1
+++ b/DAX Query View Testing Pattern/modules/Invoke-DQVTesting/Invoke-DQVTesting.psm1
@@ -20,7 +20,7 @@ $nugets = @(
         ;
         path = @("lib\netcoreapp3.0\Microsoft.AnalysisServices.AdomdClient.dll",
                  "lib\netcoreapp3.0\Microsoft.AnalysisServices.Runtime.Core.dll",
-                 "lib/netcoreapp3.0/Microsoft.AnalysisServices.Runtime.Windows.dll")
+                 "lib\netcoreapp3.0\Microsoft.AnalysisServices.Runtime.Windows.dll")
     }
 )
 


### PR DESCRIPTION
fixes #12

- bump Microsoft.AnalysisServices version to 19.84.1 so it uses the same version as the FabricPS-PBIP module.
- download ps module dependencies to the same location as the assemblies, so things don't get overwritten by other modules.